### PR TITLE
parseIni: make newline after section heading explicit (fixes #4)

### DIFF
--- a/src/Data/Ini/Config/Raw.hs
+++ b/src/Data/Ini/Config/Raw.hs
@@ -87,6 +87,7 @@ pSection leading prevs = do
   void (char '[')
   name <- T.pack `fmap` some (noneOf "[]")
   void (char ']')
+  void eol
   comments <- sBlanks
   pPairs (T.strip name) start leading prevs comments Seq.empty
 


### PR DESCRIPTION
This change makes it so that the newline following a section heading is
explicitly expected. Prior to this change, sBlanks absorbed this newline
and then it was preserved as part of the "comments" in the INI
structure, but at serialize time, we were already explicitly
re-introducing a newline after the section heading. This resulted in a
duplicate newline after each section heading in the document. This
change fixes that behavior so that the newline following a section
heading is not considered part of the document content that we need to
preserve.