### PR TITLE
Bump version before new release

### DIFF
--- a/config-ini.cabal
+++ b/config-ini.cabal
@@ -1,5 +1,5 @@
 name:             config-ini
-version:          0.2.4.0
+version:          0.2.5.0
 synopsis:         A library for simple INI-based configuration files.
 homepage:         https://github.com/aisamanra/config-ini
 bug-reports:      https://github.com/aisamanra/config-ini/issues


### PR DESCRIPTION
I don't think any semantic changes have happened since the last version bump, so this _could_ be a Cabal revision, but it'd been long enough that I forget exactly what all changed and am gonna do a new version just in case.