### PR TITLE
Fix doctest build

### DIFF
--- a/src/Data/Ini/Config/Raw.hs
+++ b/src/Data/Ini/Config/Raw.hs
@@ -164,7 +164,7 @@ sBlanks = Seq.fromList <$> many ((BlankLine <$ void eol) <|> sComment)
 
 sComment :: Parser BlankLine
 sComment = do
-  c <- oneOf ";#"
+  c <- oneOf [';', '#']
   txt <- T.pack `fmap` manyTill anySingle eol
   return (CommentLine c txt)
 
@@ -176,7 +176,7 @@ pSection :: Seq BlankLine -> Seq (NormalizedText, IniSection) -> Parser RawIni
 pSection leading prevs = do
   start <- getCurrentLine
   void (char '[')
-  name <- T.pack `fmap` some (noneOf "[]")
+  name <- T.pack `fmap` some (noneOf ['[', ']'])
   void (char ']')
   void eol
   comments <- sBlanks
@@ -211,8 +211,8 @@ pPairs name start leading prevs comments pairs = newPair <|> finishedSection
 pPair :: Seq BlankLine -> Parser (NormalizedText, IniValue)
 pPair leading = do
   pos <- getCurrentLine
-  key <- T.pack `fmap` some (noneOf "[]=:")
-  delim <- oneOf ":="
+  key <- T.pack `fmap` some (noneOf ['[', ']', '=', ':'])
+  delim <- oneOf [':', '=']
   val <- T.pack `fmap` manyTill anySingle eol
   return
     ( normalize key,


### PR DESCRIPTION
Fixes #38: apparently, the doctests have weird behavior around GHC extensions. In particular, `Data.Ini.Config.Raw` doesn't have `OverloadedStrings` set, but when it tries to load it in a doctest context, it fails because it's evaluating the code in that module as though it did. The path of least resistance here—even if it's not in theory the most correct way to handle this maybe?—is to make the code resilient to being interpreted with `OverloadedStrings`, so replacing the scant few string literals with explicit `[Char]` lists, which is arguably more correct to the code being written anyway. So: that's been done!