### PR TITLE
Allow building with `transformers-0.6.*` (GHC 9.6)

### DIFF
--- a/config-ini.cabal
+++ b/config-ini.cabal
@@ -49,7 +49,7 @@ library
                      , containers            >=0.5   && <0.7
                      , text                  >=1.2.2 && <2.1
                      , unordered-containers  >=0.2.7 && <0.3
-                     , transformers          >=0.4.1 && <0.6
+                     , transformers          >=0.4.1 && <0.7
                      , megaparsec            >=7     && <10
   default-language:    Haskell2010
 


### PR DESCRIPTION
GHC 9.6.1 bundles `transformers-0.6.1.0`.